### PR TITLE
Add composer.json, remove manual require statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+composer.lock
+vendor

--- a/classes/adobe_font_metrics.cls.php
+++ b/classes/adobe_font_metrics.cls.php
@@ -7,8 +7,6 @@
  * @version $Id$
  */
 
-require_once dirname(__FILE__)."/encoding_map.cls.php";
-
 /**
  * Adobe Font Metrics file creation utility class.
  * 

--- a/classes/font.cls.php
+++ b/classes/font.cls.php
@@ -48,8 +48,6 @@ class Font {
     }
     
     if ($class) {
-      require_once dirname(__FILE__)."/".strtolower($class).".cls.php";
-      
       $obj = new $class;
       $obj->load($file);
       

--- a/classes/font_eot.cls.php
+++ b/classes/font_eot.cls.php
@@ -7,8 +7,6 @@
  * @version $Id$
  */
 
-require_once dirname(__FILE__)."/font_truetype.cls.php";
-
 /**
  * EOT font file.
  * 

--- a/classes/font_glyph_outline.cls.php
+++ b/classes/font_glyph_outline.cls.php
@@ -7,9 +7,6 @@
  * @version $Id: font_table_glyf.cls.php 46 2012-04-02 20:22:38Z fabien.menager $
  */
 
-require_once dirname(__FILE__)."/font_glyph_outline_simple.cls.php";
-require_once dirname(__FILE__)."/font_glyph_outline_composite.cls.php";
-
 /**
  * `glyf` font table.
  * 

--- a/classes/font_opentype.cls.php
+++ b/classes/font_opentype.cls.php
@@ -7,9 +7,6 @@
  * @version $Id$
  */
 
-require_once dirname(__FILE__)."/font_truetype.cls.php";
-require_once dirname(__FILE__)."/font_opentype_table_directory_entry.cls.php";
-
 /**
  * Open Type font, the same as a TrueType one.
  * 

--- a/classes/font_opentype_table_directory_entry.cls.php
+++ b/classes/font_opentype_table_directory_entry.cls.php
@@ -7,8 +7,6 @@
  * @version $Id$
  */
 
-require_once dirname(__FILE__)."/font_truetype_table_directory_entry.cls.php";
-
 /**
  * Open Type Table directory entry, the same as a TrueType one.
  * 

--- a/classes/font_table_glyf.cls.php
+++ b/classes/font_table_glyf.cls.php
@@ -7,8 +7,6 @@
  * @version $Id$
  */
 
-require_once dirname(__FILE__)."/font_glyph_outline.cls.php";
-
 /**
  * `glyf` font table.
  * 

--- a/classes/font_table_name.cls.php
+++ b/classes/font_table_name.cls.php
@@ -7,8 +7,6 @@
  * @version $Id$
  */
 
-require_once dirname(__FILE__)."/font_table_name_record.cls.php";
-
 /**
  * `name` font table.
  * 

--- a/classes/font_truetype.cls.php
+++ b/classes/font_truetype.cls.php
@@ -7,13 +7,6 @@
  * @version $Id$
  */
 
-$dir = dirname(__FILE__);
-require_once "$dir/font_binary_stream.cls.php";
-require_once "$dir/font_truetype_table_directory_entry.cls.php";
-require_once "$dir/font_truetype_header.cls.php";
-require_once "$dir/font_table.cls.php";
-require_once "$dir/adobe_font_metrics.cls.php";
-
 /**
  * TrueType font file.
  * 

--- a/classes/font_truetype_collection.cls.php
+++ b/classes/font_truetype_collection.cls.php
@@ -7,9 +7,6 @@
  * @version $Id$
  */
 
-require_once dirname(__FILE__)."/font_binary_stream.cls.php";
-require_once dirname(__FILE__)."/font_truetype.cls.php";
-
 /**
  * TrueType collection font file.
  * 

--- a/classes/font_truetype_header.cls.php
+++ b/classes/font_truetype_header.cls.php
@@ -7,8 +7,6 @@
  * @version $Id$
  */
 
-require_once dirname(__FILE__)."/font_header.cls.php";
-
 /**
  * TrueType font file header.
  * 

--- a/classes/font_truetype_table_directory_entry.cls.php
+++ b/classes/font_truetype_table_directory_entry.cls.php
@@ -7,8 +7,6 @@
  * @version $Id$
  */
 
-require_once dirname(__FILE__)."/font_table_directory_entry.cls.php";
-
 /**
  * TrueType table directory entry.
  * 

--- a/classes/font_woff.cls.php
+++ b/classes/font_woff.cls.php
@@ -7,10 +7,6 @@
  * @version $Id$
  */
 
-require_once dirname(__FILE__)."/font_truetype.cls.php";
-require_once dirname(__FILE__)."/font_woff_table_directory_entry.cls.php";
-require_once dirname(__FILE__)."/font_woff_header.cls.php";
-
 /**
  * WOFF font file.
  * 

--- a/classes/font_woff_header.cls.php
+++ b/classes/font_woff_header.cls.php
@@ -7,8 +7,6 @@
  * @version $Id$
  */
 
-require_once dirname(__FILE__)."/font_truetype_header.cls.php";
-
 /**
  * WOFF font file header.
  * 

--- a/classes/font_woff_table_directory_entry.cls.php
+++ b/classes/font_woff_table_directory_entry.cls.php
@@ -7,8 +7,6 @@
  * @version $Id$
  */
 
-require_once dirname(__FILE__)."/font_table_directory_entry.cls.php";
-
 /**
  * WOFF font file table directory entry.
  * 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "phenx/php-font-lib",
+    "type": "library",
+    "description": "A library to read, parse, export and make subsets of different types of font files.",
+    "homepage": "https://github.com/PhenX/php-font-lib",
+    "license": "LGPL",
+    "authors": [
+        {
+            "name": "Fabien Ménager",
+            "email": "fabien.menager@gmail.com"
+        }
+    ],
+    "autoload": {
+        "classmap": ["classes/"]
+    }
+}

--- a/www/font_info.php
+++ b/www/font_info.php
@@ -29,7 +29,7 @@
 <body>
 <?php 
 
-require_once "../classes/font.cls.php";
+require_once dirname(__FILE___)."/../vendor/autoload.php";
 
 $fontfile   = @$_GET["fontfile"];
 $unicodemap = @$_GET["unicodemap"];

--- a/www/make_subset.php
+++ b/www/make_subset.php
@@ -15,8 +15,8 @@ if (isset($_POST["subset"])) {
   
   ob_start();
   
-  require_once "../classes/font.cls.php";
   
+  require_once dirname(__FILE___)."/../vendor/autoload.php";
   $font = Font::load($fontfile);
   $font->parse();
   

--- a/www/test.php
+++ b/www/test.php
@@ -8,8 +8,7 @@
 <pre>
 <?php 
 
-require_once "../classes/font_binary_stream.cls.php";
-require_once "../classes/font.cls.php";
+require_once dirname(__FILE___)."/../vendor/autoload.php";
 
 $t = microtime(true);
 


### PR DESCRIPTION
I added a composer.json for this package so we can list it as a dependency for DOMPDF. I have used the composer "classmap" function which simply creates a lookup table of all the classes available under `classes/`.

If you run `composer update` in the package directory, it will create a valid autoloader under `vendor/autoload.php`.
