### PR TITLE
Add composer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+composer.lock
+vendor

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "phenx/php-font-lib",
+    "type": "library",
+    "description": "A library to read, parse, export and make subsets of different types of font files.",
+    "homepage": "https://github.com/PhenX/php-font-lib",
+    "license": "LGPL",
+    "authors": [
+        {
+            "name": "Fabien Ménager",
+            "email": "fabien.menager@gmail.com"
+        }
+    ],
+    "autoload": {
+        "classmap": ["classes/"]
+    }
+}


### PR DESCRIPTION
I've added a basic composer.json to this project so that we can list it as a dependency of DOMPDF.

You can now generate a valid `autoload.php` file by running `composer update` in the package root. Originally I went through the existing classes and removed all the `require_once` statements, but I decided it's probably better to leave them there for now, to support anyone still manually including this package.
