### PR TITLE
Fix order of class definition

### DIFF
--- a/classes/Font_Glyph_Outline.php
+++ b/classes/Font_Glyph_Outline.php
@@ -7,9 +7,6 @@
  * @version $Id: Font_Table_glyf.php 46 2012-04-02 20:22:38Z fabien.menager $
  */
 
-require_once dirname(__FILE__) . "/Font_Glyph_Outline_Simple.php";
-require_once dirname(__FILE__) . "/Font_Glyph_Outline_Composite.php";
-
 /**
  * `glyf` font table.
  *
@@ -105,3 +102,6 @@ class Font_Glyph_Outline extends Font_Binary_Stream {
     return array();
   }
 }
+
+require_once dirname(__FILE__) . "/Font_Glyph_Outline_Simple.php";
+require_once dirname(__FILE__) . "/Font_Glyph_Outline_Composite.php";


### PR DESCRIPTION
As indicated in the documentation on inheritance, PHP 
requires that classes be defined before they are used.
In terms of a class that extends another class, the 
parent should be defined before the child. Earlier 
versions of PHP (and indeed the current version) may 
have been lenient on this point, but most opcache 
engines enforce the stricter ordering requirement.

References:
- http://www.php.net/manual/en/language.oop5.inheritance.php
