### PR TITLE
Bug fix for spamming error log in case of memory issue.

### DIFF
--- a/classes/Font_Binary_Stream.php
+++ b/classes/Font_Binary_Stream.php
@@ -145,7 +145,7 @@ class Font_Binary_Stream {
   }
 
   public function write($data, $length = null) {
-    if ($data === null || $data === "") {
+    if ($data === null || $data === "" || $data === false) {
       return 0;
     }
     


### PR DESCRIPTION
- When web server has memory issue, it is getting 'false' which should not pass to fwrite function. Adding another condition to prevent it.
