### PR TITLE
Add paths and folders to be export-ignored to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,10 @@
 *.html  text
 *.txt   text
 *.svg   text
+
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/phpunit.xml.dist   export-ignore
+/sample-fonts       export-ignore
+/tests              export-ignore


### PR DESCRIPTION
Add paths to `.gitattributes` with the `export-ignore` flag set, so they're not pulled down as part of a project's dependencies via Composer.