### PR TITLE
Use MBString functions for 8bit data read

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
     "config": {
         "bin-dir": "bin"
     },
+    "require": {
+        "ext-mbstring": "*"
+    },
     "require-dev": {
         "symfony/phpunit-bridge" : "^3 || ^4 || ^5"
     }

--- a/src/FontLib/EOT/File.php
+++ b/src/FontLib/EOT/File.php
@@ -74,8 +74,7 @@ class File extends \FontLib\TrueType\File {
     }
 
     $string = fread($this->f, $n);
-    $chunks = str_split($string, 2);
-    $chunks = array_map("strrev", $chunks);
+    $chunks = mb_str_split($string, 2, '8bit');
 
     return implode("", $chunks);
   }

--- a/src/FontLib/Glyph/Outline.php
+++ b/src/FontLib/Glyph/Outline.php
@@ -96,7 +96,7 @@ class Outline extends BinaryStream {
   function encode() {
     $font = $this->getFont();
 
-    return $font->write($this->raw, strlen($this->raw));
+    return $font->write($this->raw, mb_strlen($this->raw, '8bit'));
   }
 
   function getSVGContours() {

--- a/src/FontLib/Table/DirectoryEntry.php
+++ b/src/FontLib/Table/DirectoryEntry.php
@@ -37,14 +37,14 @@ class DirectoryEntry extends BinaryStream {
   protected $origF;
 
   static function computeChecksum($data) {
-    $len = strlen($data);
+    $len = mb_strlen($data, '8bit');
     $mod = $len % 4;
 
     if ($mod) {
       $data = str_pad($data, $len + (4 - $mod), "\0");
     }
 
-    $len = strlen($data);
+    $len = mb_strlen($data, '8bit');
 
     $hi = 0x0000;
     $lo = 0x0000;

--- a/src/FontLib/TrueType/File.php
+++ b/src/FontLib/TrueType/File.php
@@ -124,7 +124,7 @@ class File extends BinaryStream {
   }
 
   function utf8toUnicode($str) {
-    $len = strlen($str);
+    $len = mb_strlen($str, '8bit');
     $out = array();
 
     for ($i = 0; $i < $len; $i++) {

--- a/src/FontLib/WOFF/File.php
+++ b/src/FontLib/WOFF/File.php
@@ -50,7 +50,7 @@ class File extends \FontLib\TrueType\File {
       }
 
       // Prepare data ...
-      $length        = strlen($data);
+      $length        = mb_strlen($data, '8bit');
       $entry->length = $entry->origLength = $length;
       $entry->offset = $dataOffset;
 


### PR DESCRIPTION
Some of these aren't necessary? Then again the PHP documentation doesn't always explicitly state that functions read variable data in a byte-wise manner.

MBString was already in use in the library and thus a dependency already. As such this change does not break backwards compatibility. A future release should be able to remove the MBString dependency since overrides are going away and we should be able to use stock PHP methods.