### PR TITLE
Fix one more deprecation notice with PHP 8.1

### DIFF
--- a/src/FontLib/Glyph/Outline.php
+++ b/src/FontLib/Glyph/Outline.php
@@ -33,6 +33,9 @@ class Outline extends BinaryStream {
   public $xMax;
   public $yMax;
 
+  /**
+   * @var string|null
+   */
   public $raw;
 
   /**
@@ -96,7 +99,7 @@ class Outline extends BinaryStream {
   function encode() {
     $font = $this->getFont();
 
-    return $font->write($this->raw, mb_strlen($this->raw, '8bit'));
+    return $font->write($this->raw, mb_strlen((string) $this->raw, '8bit'));
   }
 
   function getSVGContours() {


### PR DESCRIPTION
When using font subsetting via CPDF, an empty font file is created and opened initially, and `$this->raw` will be `null` at this point.

See https://github.com/dompdf/dompdf/pull/2668#issuecomment-996896902.