### PR TITLE
Fix more cases of potentially passing non-string to string functions

### DIFF
--- a/src/FontLib/BinaryStream.php
+++ b/src/FontLib/BinaryStream.php
@@ -137,12 +137,17 @@ class BinaryStream {
     fseek($this->f, $n, SEEK_CUR);
   }
 
+  /**
+   * @param int $n The number of bytes to read
+   *
+   * @return string
+   */
   public function read($n) {
     if ($n < 1) {
       return "";
     }
 
-    return fread($this->f, $n);
+    return (string) fread($this->f, $n);
   }
 
   public function write($data, $length = null) {

--- a/src/FontLib/EOT/File.php
+++ b/src/FontLib/EOT/File.php
@@ -61,19 +61,19 @@ class File extends \FontLib\TrueType\File {
     // TODO Read font data ...
   }
 
-    /**
-     * Little endian version of the read method
-     *
-     * @param int $n The number of bytes to read
-     *
-     * @return string
-     */
+  /**
+   * Little endian version of the read method
+   *
+   * @param int $n The number of bytes to read
+   *
+   * @return string
+   */
   public function read($n) {
     if ($n < 1) {
       return "";
     }
 
-    $string = fread($this->f, $n);
+    $string = (string) fread($this->f, $n);
     $chunks = mb_str_split($string, 2, '8bit');
 
     return implode("", $chunks);

--- a/src/FontLib/Table/DirectoryEntry.php
+++ b/src/FontLib/Table/DirectoryEntry.php
@@ -36,6 +36,11 @@ class DirectoryEntry extends BinaryStream {
 
   protected $origF;
 
+  /**
+   * @param string $data
+   *
+   * @return int
+   */
   static function computeChecksum($data) {
     $len = mb_strlen($data, '8bit');
     $mod = $len % 4;

--- a/src/FontLib/WOFF/File.php
+++ b/src/FontLib/WOFF/File.php
@@ -46,7 +46,7 @@ class File extends \FontLib\TrueType\File {
       $data = $this->read($entry->length);
 
       if ($entry->length < $entry->origLength) {
-        $data = gzuncompress($data);
+        $data = (string) gzuncompress($data);
       }
 
       // Prepare data ...


### PR DESCRIPTION
Ignore read or uncompress errors explicitly by treating a `false` return value as empty string. `BinaryStream::write()` already handles `false` values for `$data` by writing nothing, so this seems to be the original intention.