### PR TITLE
Update README.md with "$font->close()".

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,5 @@ echo $font->getFontFullName() .'<br>';
 echo $font->getFontVersion() .'<br>';
 echo $font->getFontWeight() .'<br>';
 echo $font->getFontPostscriptName() .'<br>';
+$font->close();
 ```


### PR DESCRIPTION
Add `$font->close();` to example in README file.

In the case where you have a script that uses this library to read / parse a lot of fonts at once, it is a good idea to call `$font->close();` in order to free up the system processes. If you don't, you may get a "failed to open dir: Too many open files" exception thrown.