### PR TITLE
Fix composite glyph

### DIFF
--- a/src/FontLib/Glyph/OutlineComposite.php
+++ b/src/FontLib/Glyph/OutlineComposite.php
@@ -129,6 +129,11 @@ class OutlineComposite extends Outline {
 
       $this->components[] = $component;
     } while ($flags & self::MORE_COMPONENTS);
+    if ($flags & self::WE_HAVE_INSTRUCTIONS) {
+      $numInstr = $font->readUInt16();
+      $instr = $font->read($numInstr);
+      $this->components[count($this->components) - 1]->instructions = pack('n', $numInstr) . $instr;
+    }
   }
 
   function encode() {
@@ -171,6 +176,8 @@ class OutlineComposite extends Outline {
 
       if ($_i < count($this->components) - 1) {
         $flags |= self::MORE_COMPONENTS;
+      } elseif($_component->instructions !== null) {
+        $flags |= self::WE_HAVE_INSTRUCTIONS;
       }
 
       $size += $font->writeUInt16($flags);
@@ -212,6 +219,10 @@ class OutlineComposite extends Outline {
         $size += $font->writeInt16($_component->c);
         $size += $font->writeInt16($_component->d);
       }
+    }
+
+    if($_component->instructions !== null) {
+      $size += $font->write($_component->instructions, strlen($_component->instructions));
     }
 
     return $size;

--- a/src/FontLib/Table/Type/cvt.php
+++ b/src/FontLib/Table/Type/cvt.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @package php-font-lib
+ * @link    https://github.com/PhenX/php-font-lib
+ * @author  Fabien Ménager <fabien.menager@gmail.com>
+ * @license http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace FontLib\Table\Type;
+use FontLib\Table\Table;
+
+/**
+ * `cvt ` font table.
+ *
+ * @package php-font-lib
+ */
+class cvt extends Table {
+  private $rawData;
+  protected function _parse() {
+    $font = $this->getFont();
+    $font->seek($this->entry->offset);
+    $this->rawData = $font->read($this->entry->length);
+  }
+  function _encode() {
+    return $this->getFont()->write($this->rawData, $this->entry->length);
+  }
+}

--- a/src/FontLib/Table/Type/fpgm.php
+++ b/src/FontLib/Table/Type/fpgm.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @package php-font-lib
+ * @link    https://github.com/PhenX/php-font-lib
+ * @author  Fabien Ménager <fabien.menager@gmail.com>
+ * @license http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace FontLib\Table\Type;
+use FontLib\Table\Table;
+
+/**
+ * `fpgm` font table.
+ *
+ * @package php-font-lib
+ */
+class fpgm extends Table {
+  private $rawData;
+  protected function _parse() {
+    $font = $this->getFont();
+    $font->seek($this->entry->offset);
+    $this->rawData = $font->read($this->entry->length);
+  }
+  function _encode() {
+    return $this->getFont()->write($this->rawData, $this->entry->length);
+  }
+}

--- a/src/FontLib/Table/Type/prep.php
+++ b/src/FontLib/Table/Type/prep.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @package php-font-lib
+ * @link    https://github.com/PhenX/php-font-lib
+ * @author  Fabien Ménager <fabien.menager@gmail.com>
+ * @license http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace FontLib\Table\Type;
+
+use FontLib\Table\Table;
+
+/**
+ * `prep` font table.
+ *
+ * @package php-font-lib
+ */
+class prep extends Table
+{
+  private $rawData;
+  protected function _parse() {
+    $font = $this->getFont();
+    $font->seek($this->entry->offset);
+    $this->rawData = $font->read($this->entry->length);
+  }
+  function _encode() {
+    return $this->getFont()->write($this->rawData, $this->entry->length);
+  }
+}

--- a/src/FontLib/TrueType/File.php
+++ b/src/FontLib/TrueType/File.php
@@ -217,8 +217,7 @@ class File extends BinaryStream {
 
   function encode($tags = array()) {
     if (!self::$raw) {
-      $tags = array_merge(array("head", "hhea", "cmap", "hmtx", "maxp", "glyf", "loca", "name", "post"), $tags);
-      $optionalTags = array("cvt ", "fpgm", "prep");
+      $tags = array_merge(array("head", "hhea", "cmap", "hmtx", "maxp", "glyf", "loca", "name", "post", "cvt ", "fpgm", "prep"), $tags);
     }
     else {
       $tags = array_keys($this->directory);
@@ -237,11 +236,6 @@ class File extends BinaryStream {
       }
 
       $entries[$tag] = $this->directory[$tag];
-    }
-    foreach ($optionalTags as $tag) {
-      if (isset($this->directory[$tag])) {
-        $entries[$tag] = $this->directory[$tag];
-      }
     }
 
     $num_tables = count($entries);

--- a/src/FontLib/TrueType/File.php
+++ b/src/FontLib/TrueType/File.php
@@ -218,12 +218,12 @@ class File extends BinaryStream {
   function encode($tags = array()) {
     if (!self::$raw) {
       $tags = array_merge(array("head", "hhea", "cmap", "hmtx", "maxp", "glyf", "loca", "name", "post"), $tags);
+      $optionalTags = array("cvt ", "fpgm", "prep");
     }
     else {
       $tags = array_keys($this->directory);
     }
 
-    $num_tables = count($tags);
     $n          = 16; // @todo
 
     Font::d("Tables : " . implode(", ", $tags));
@@ -238,6 +238,13 @@ class File extends BinaryStream {
 
       $entries[$tag] = $this->directory[$tag];
     }
+    foreach ($optionalTags as $tag) {
+      if (isset($this->directory[$tag])) {
+        $entries[$tag] = $this->directory[$tag];
+      }
+    }
+
+    $num_tables = count($entries);
 
     $this->header->data["numTables"] = $num_tables;
     $this->header->encode();


### PR DESCRIPTION
Fix Composite Glyph Output

![overview](https://user-images.githubusercontent.com/15166082/212473286-1e650784-aa52-4dcf-9af7-80f39af7eb1a.png)

## Problem Reproduction

1. download [kaiu.ttf](https://github.com/thumbb13555/PDFMakerExample/blob/master/app/src/main/assets/kaiu.ttf) and use [dompdf/utils](https://github.com/dompdf/utils) to load font
2. test code
```php
<?php
require('vendor/autoload.php');

use Dompdf\Dompdf;

$dompdf = new Dompdf();
$dompdf->loadHtml('
    <style>
    .font-zh {
        font-family: "kaiu";
        font-size: 14;
    }
    </style>
 
    <p class="font-zh">月落烏啼霜滿天<br>江楓漁火對愁眠<br>姑蘇城外寒山寺<br>夜半鐘聲到客船</p>
');

$dompdf->setPaper('A4', 'protrait');

$dompdf->render();

$dompdf->stream('test.pdf', [
    'Attachment' => 0
]);
```

## Related Reference

1. [PDF 1.7 Reference](https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/pdfreference1.7old.pdf) page 468

> The following TrueType tables are always required: “head,” “hhea,” “loca,” “maxp,” “cvt ,” “prep,” “glyf,” “hmtx,” and “fpgm.” If used with a simple font dictionary, the font program must additionally contain a “cmap” table.

2. The C pseudo-code in [OpenType spec - glyf](https://learn.microsoft.com/en-us/typography/opentype/spec/glyf)

```
do {
    uint16 flags;
    uint16 glyphIndex;
    if ( flags & ARG_1_AND_2_ARE_WORDS) {
    (int16 or FWORD) argument1;
    (int16 or FWORD) argument2;
    } else {
        uint16 arg1and2; /* (arg1 << 8) | arg2 */
    }
    if ( flags & WE_HAVE_A_SCALE ) {
        F2DOT14  scale;    /* Format 2.14 */
    } else if ( flags & WE_HAVE_AN_X_AND_Y_SCALE ) {
        F2DOT14  xscale;    /* Format 2.14 */
        F2DOT14  yscale;    /* Format 2.14 */
    } else if ( flags & WE_HAVE_A_TWO_BY_TWO ) {
        F2DOT14  xscale;    /* Format 2.14 */
        F2DOT14  scale01;   /* Format 2.14 */
        F2DOT14  scale10;   /* Format 2.14 */
        F2DOT14  yscale;    /* Format 2.14 */
    }
} while ( flags & MORE_COMPONENTS )
if (flags & WE_HAVE_INSTR){
    uint16 numInstr
    uint8 instr[numInstr]
```
