### PR TITLE
Fix crashing google fonts or other TTF font files

### DIFF
--- a/src/FontLib/BinaryStream.php
+++ b/src/FontLib/BinaryStream.php
@@ -215,7 +215,10 @@ class BinaryStream {
   }
 
   public function readInt16() {
-    $a = unpack("nn", $this->read(2));
+    $data = $this->read(2);
+    if (!$data) return null;
+
+    $a = unpack("nn", $data);
     $v = $a["n"];
 
     if ($v >= 0x8000) {


### PR DESCRIPTION
We encountered a lot of issues with `unpack` errors in BinaryStream (see: #47 ) for some of the fonts hosted by Google.
The real fix would probably be to better understand the differences in the table definitions. We tried to check this using ttfdump or manually checking the font files, but we didn't find any big issues there. The codebase is pretty old and difficult to debug. So i don't know if anyone would be interested to investigate or fix this in a better way. 

This commit solves the problem for us. The library is not crashing and fonts are being rendered in DOMPDF. 