### PR TITLE
Fix reading left side bearings

### DIFF
--- a/src/FontLib/Table/Type/hmtx.php
+++ b/src/FontLib/Table/Type/hmtx.php
@@ -39,8 +39,9 @@ class hmtx extends Table {
       $numLeft   = $numGlyphs - $numOfLongHorMetrics;
       $metrics   = $font->readUInt16Many($numLeft);
       for($i = 0; $i < $numLeft; $i++) {
-        $gid        = $numOfLongHorMetrics + $i;
-        $data[$gid] = array($lastWidth, $metrics[$i]);
+        $gid             = $numOfLongHorMetrics + $i;
+        $leftSideBearing = isset($metrics[$i]) ? $metrics[$i] : 0;
+        $data[$gid]      = array($lastWidth, $leftSideBearing);
       }
     }
 

--- a/src/FontLib/Table/Type/hmtx.php
+++ b/src/FontLib/Table/Type/hmtx.php
@@ -35,8 +35,13 @@ class hmtx extends Table {
     }
 
     if ($numOfLongHorMetrics < $numGlyphs) {
-      $lastWidth = end($data);
-      $data      = array_pad($data, $numGlyphs, $lastWidth);
+      $lastWidth = end($data)[0];
+      $numLeft   = $numGlyphs - $numOfLongHorMetrics;
+      $metrics   = $font->readUInt16Many($numLeft);
+      for($i = 0; $i < $numLeft; $i++) {
+        $gid        = $numOfLongHorMetrics + $i;
+        $data[$gid] = array($lastWidth, $metrics[$i]);
+      }
     }
 
     $this->data = $data;


### PR DESCRIPTION
Some character render wrong position.

The image shows text rendering before fixing and after fixing.

![before fixing and after fixing](https://github.com/dompdf/php-font-lib/assets/15166082/54a3db63-f4a3-4ac7-a7e8-194464c0ee94)

## Related specification documents

[https://learn.microsoft.com/en-us/typography/opentype/spec/hmtx](https://learn.microsoft.com/en-us/typography/opentype/spec/hmtx)

> If numberOfHMetrics is less than the total number of glyphs, then the hMetrics array is followed by an array for the left side bearing values of the remaining glyphs.

## Testing code

using font：[fonts.zip](https://github.com/dompdf/php-font-lib/files/12683963/fonts.zip)

```php
<?php

require(__DIR__ . '/vendor/autoload.php');

use Dompdf\Dompdf;

$html = <<<EOT
<style>
    @font-face {
        font-family: "noto";
        src: url("fonts/NotoSerifTC-Regular.ttf") format('truetype');
        font-weight: normal;
        font-style: normal;
    }
    body{
        font-family: 'noto';
    }
</style>
<p>當一個有趣的人</p>
EOT;

$dompdf = new Dompdf([
    'chroot' => __DIR__
]);
$dompdf->loadHtml($html);
$dompdf->render();
$dompdf->stream('demo.pdf', [
    'Attachment' => 0
]);
```


