### PR TITLE
Fix path to maps in AdobeFontMetrics.php

### DIFF
--- a/src/FontLib/AdobeFontMetrics.php
+++ b/src/FontLib/AdobeFontMetrics.php
@@ -33,7 +33,7 @@ class AdobeFontMetrics {
 
     if ($encoding) {
       $encoding = preg_replace("/[^a-z0-9-_]/", "", $encoding);
-      $map_file = dirname(__FILE__) . "/../maps/$encoding.map";
+      $map_file = dirname(__FILE__) . "/../../maps/$encoding.map";
       if (!file_exists($map_file)) {
         throw new \Exception("Unknown encoding ($encoding)");
       }


### PR DESCRIPTION
Currently get `Fatal error: Uncaught Exception: Unknown encoding` whenever passing an encoding to `saveAdobeFontMetrics`.  This is because we aren't correctly pointing to the `maps/` directory.

`dirname(__FILE__)` gives you `php-font-lib/src/Fontlib` `dirname(__FILE__) . '/../'` gives you `php-font-lib/src/`

We need one more level up, to hit /maps.

P.S.  We can also use `__DIR__ . '/../../'` OR `dirname(__DIR__) . '/../'`