### PR TITLE
Add platformID/platformSpecificID/languageID support to getNameTableString

### DIFF
--- a/src/FontLib/AdobeFontMetrics.php
+++ b/src/FontLib/AdobeFontMetrics.php
@@ -54,7 +54,8 @@ class AdobeFontMetrics {
     $this->addPair("EncodingScheme", $encoding_scheme);
 
     $records = $font->getData("name", "records");
-    foreach ($records as $id => $record) {
+    foreach ($records as $uniqueIdentifier => $record) {
+      $id = end(explode(',', $uniqueIdentifier));
       if (!isset(name::$nameIdCodes[$id]) || preg_match("/[\r\n]/", $record->string)) {
         continue;
       }

--- a/src/FontLib/Table/Type/name.php
+++ b/src/FontLib/Table/Type/name.php
@@ -160,8 +160,16 @@ class name extends Table {
 
       $encoding = null;
       switch ($record->platformID) {
+        case 1:
+          $encoding = mb_detect_encoding($record->stringRaw, array('UTF-8', 'ASCII', 'GB2312', 'GB18030', 'GBK', 'SJIS', 'BIG-5'));
+          break;
         case 3:
           switch ($record->platformSpecificID) {
+            case 1:
+              if (\array_key_exists("GBK", $system_encodings)) {
+                $encoding = "GBK";
+              }
+              break;
             case 2:
               if (\array_key_exists("SJIS", $system_encodings)) {
                 $encoding = "SJIS";
@@ -185,19 +193,19 @@ class name extends Table {
           }
           break;
       }
-      if ($encoding === null) {
+      if ($encoding === null || $encoding === false) {
         $encoding = "UTF-16";
       }
 
       $record->string = mb_convert_encoding($record->stringRaw, "UTF-8", $encoding);
+
       if (strpos($record->string, "\0") !== false) {
         $record->string = str_replace("\0", "", $record->string);
       }
-      $names[$record->nameID] = $record;
+      $names["{$record->platformID},{$record->platformSpecificID},{$record->languageID},{$record->nameID}"] = $record;
     }
 
     $data["records"] = $names;
-
     $this->data = $data;
   }
 

--- a/src/FontLib/TrueType/File.php
+++ b/src/FontLib/TrueType/File.php
@@ -169,7 +169,6 @@ class File extends BinaryStream {
 
   function getTable() {
     $this->parseTableEntries();
-
     return $this->directory;
   }
 
@@ -392,7 +391,6 @@ class File extends BinaryStream {
     if (!empty($this->directory)) {
       return;
     }
-
     if (empty($this->header->data["numTables"])) {
       return;
     }
@@ -504,8 +502,8 @@ class File extends BinaryStream {
    *
    * @return string|null
    */
-  function getFontCopyright() {
-    return $this->getNameTableString(name::NAME_COPYRIGHT);
+  function getFontCopyright($platformID, $platformSpecificID, $languageID) {
+    return $this->getNameTableString("{$platformID},{$platformSpecificID},{$languageID}," . name::NAME_COPYRIGHT);
   }
 
   /**
@@ -513,8 +511,8 @@ class File extends BinaryStream {
    *
    * @return string|null
    */
-  function getFontName() {
-    return $this->getNameTableString(name::NAME_NAME);
+  function getFontName($platformID, $platformSpecificID, $languageID) {
+    return $this->getNameTableString("{$platformID},{$platformSpecificID},{$languageID}," . name::NAME_NAME);
   }
 
   /**
@@ -522,8 +520,8 @@ class File extends BinaryStream {
    *
    * @return string|null
    */
-  function getFontSubfamily() {
-    return $this->getNameTableString(name::NAME_SUBFAMILY);
+  function getFontSubfamily($platformID, $platformSpecificID, $languageID) {
+    return $this->getNameTableString("{$platformID},{$platformSpecificID},{$languageID}," . name::NAME_SUBFAMILY);
   }
 
   /**
@@ -531,8 +529,8 @@ class File extends BinaryStream {
    *
    * @return string|null
    */
-  function getFontSubfamilyID() {
-    return $this->getNameTableString(name::NAME_SUBFAMILY_ID);
+  function getFontSubfamilyID($platformID, $platformSpecificID, $languageID) {
+    return $this->getNameTableString("{$platformID},{$platformSpecificID},{$languageID}," . name::NAME_SUBFAMILY_ID);
   }
 
   /**
@@ -540,8 +538,8 @@ class File extends BinaryStream {
    *
    * @return string|null
    */
-  function getFontFullName() {
-    return $this->getNameTableString(name::NAME_FULL_NAME);
+  function getFontFullName($platformID, $platformSpecificID, $languageID) {
+    return $this->getNameTableString("{$platformID},{$platformSpecificID},{$languageID}," . name::NAME_FULL_NAME);
   }
 
   /**
@@ -549,8 +547,8 @@ class File extends BinaryStream {
    *
    * @return string|null
    */
-  function getFontVersion() {
-    return $this->getNameTableString(name::NAME_VERSION);
+  function getFontVersion($platformID, $platformSpecificID, $languageID) {
+    return $this->getNameTableString("{$platformID},{$platformSpecificID},{$languageID}," . name::NAME_VERSION);
   }
 
   /**
@@ -567,8 +565,8 @@ class File extends BinaryStream {
    *
    * @return string|null
    */
-  function getFontPostscriptName() {
-    return $this->getNameTableString(name::NAME_POSTSCRIPT_NAME);
+  function getFontPostscriptName($platformID, $platformSpecificID, $languageID) {
+    return $this->getNameTableString("{$platformID},{$platformSpecificID},{$languageID}," . name::NAME_POSTSCRIPT_NAME);
   }
 
   function reduce() {


### PR DESCRIPTION
Adding this functionality would make it possible to obtain data for different platforms or languages, and might also prevent conflicts for the same entries.

This is a font for testing:
[方正兰亭圆_GBK_准.ttf.zip](https://github.com/dompdf/php-font-lib/files/14275234/_GBK_.ttf.zip)
```
% font info 1.ttf
Mac (1,0,0,1) Font Family: FZLanTingYuan-M-GBK
Mac (1,0,0,2) Font Subfamily: Regular
Mac (1,0,0,3) Unique Identifier: Founder:FZLanTingYuan-M-GBK	Regular
Mac (1,0,0,4) Full Name: FZLanTingYuan-M-GBK
Mac (1,0,0,5) Version: 1.00
Mac (1,0,0,6) PostScript Name: FZLANTY_ZHUNK--GBK1-0
Mac (1,25,33,1) Font Family: ??????ͤԲ_GBK_׼
Mac (1,25,33,2) Font Subfamily: Regular
Mac (1,25,33,3) Unique Identifier: Founder:??????ͤԲ_GBK_׼	Regular
Mac (1,25,33,4) Full Name: ??????ͤԲ_GBK_׼
Mac (1,25,33,5) Version: 1.00
Mac (1,25,33,6) PostScript Name: FZLANTY_ZHUNK--GBK1-0
Microsoft (3,1,1033,1) Font Family: FZLanTingYuan-M-GBK
Microsoft (3,1,1033,2) Font Subfamily: Regular
Microsoft (3,1,1033,3) Unique Identifier: Founder:FZLanTingYuan-M-GBK	Regular
Microsoft (3,1,1033,4) Full Name: FZLanTingYuan-M-GBK
Microsoft (3,1,1033,5) Version: 1.00
Microsoft (3,1,1033,6) PostScript Name: FZLANTY_ZHUNK--GBK1-0
Microsoft (3,1,2052,1) Font Family: 方正兰亭圆_GBK_准
Microsoft (3,1,2052,2) Font Subfamily: Regular
Microsoft (3,1,2052,3) Unique Identifier: Founder:方正兰亭圆_GBK_准	Regular
Microsoft (3,1,2052,4) Full Name: 方正兰亭圆_GBK_准
Microsoft (3,1,2052,5) Version: 1.00
Microsoft (3,1,2052,6) PostScript Name: FZLANTY_ZHUNK--GBK1-0
```

For example: do a simple test on the original version
```
% cat 1.php
<?php
require_once('vendor/autoload.php');

function GetMatchedFontInfo(string $fontfile): nulløFontLibØTrueTypeØFileøFontLibØTrueTypeØCollection æ
	$fontInfo = FontLibØFont::load(($fontfile));
		try æ
			$fontInfo->parse();
			return $fontInfo;
		å catch (Throwable $e) æ
		å
		try æ
			$fontInfo->close();
		å catch (Throwable $e) æ
		å
	return null;
å

function GetSubsetFont(?FontLibØTrueTypeØFile $fontInfo, string $targetFile) æ
	if ($fontInfo === null) æ
		return;
	å
	$fontInfo->setSubset('test');
	if ($fontInfo->open($targetFile, FontLibØBinaryStream::modeReadWrite)) æ
		$fontInfo->encode(array("OS/2"));
	å
å
$font = GetMatchedFontInfo('1.ttf');
$data = $font->getFontName(); // NAME_NAME (ttf): 1
var_dump($data);
% php 1.php
string(23) "方正兰亭圆_GBK_准"
```
Mac (1,0,0,1) Font Family: FZLanTingYuan-M-GBK
Microsoft (3,1,1033,1) Font Family: FZLanTingYuan-M-GBK

You'll find that it may not match the output you expected for the language or platform.
The essential reason for this problem is that the name class is able to parse but does not set enough information when parse.

Therefore, this PR adds a way for users to obtain information on any platform or language. The trade-off is that if the user doesn't know the type they want to deal with, they have to guess to get the font information. So, this is where optimization is needed.