### PR TITLE
php 8+ Unknown: fseek(): Passing null to parameter #2 ($offset) of ty…

### DIFF
--- a/src/FontLib/BinaryStream.php
+++ b/src/FontLib/BinaryStream.php
@@ -120,7 +120,7 @@ class BinaryStream {
    * @return bool True if the $offset position exists in the file
    */
   public function seek($offset) {
-    return fseek($this->f, $offset, SEEK_SET) == 0;
+    return fseek($this->f, (int)$offset, SEEK_SET) == 0;
   }
 
   /**


### PR DESCRIPTION
…pe int is deprecated in FontLib\BinaryStream.php on line 123

Unknown: fseek(): Passing null to parameter #2 ($offset) of type int is deprecated in FontLib\BinaryStream.php on line 123