### PR TITLE
Declare return types for font collection iterator methods

### DIFF
--- a/src/FontLib/TrueType/Collection.php
+++ b/src/FontLib/TrueType/Collection.php
@@ -30,7 +30,7 @@ class Collection extends BinaryStream implements Iterator, Countable {
   protected $version;
   protected $numFonts;
 
-  function parse() {
+  function parse() : void {
     if (isset($this->numFonts)) {
       return;
     }
@@ -51,7 +51,7 @@ class Collection extends BinaryStream implements Iterator, Countable {
    * @throws OutOfBoundsException
    * @return File
    */
-  function getFont($fontId) {
+  function getFont($fontId) : File {
     $this->parse();
 
     if (!isset($this->collectionOffsets[$fontId])) {
@@ -69,29 +69,29 @@ class Collection extends BinaryStream implements Iterator, Countable {
     return $this->collection[$fontId] = $font;
   }
 
-  function current() {
+  function current() : File {
     return $this->getFont($this->position);
   }
 
-  function key() {
+  function key() : int {
     return $this->position;
   }
 
-  function next() {
-    return ++$this->position;
+  function next() : void {
+    ++$this->position;
   }
 
-  function rewind() {
+  function rewind() : void {
     $this->position = 0;
   }
 
-  function valid() {
+  function valid() : bool {
     $this->parse();
 
     return isset($this->collectionOffsets[$this->position]);
   }
 
-  function count() {
+  function count(): int {
     $this->parse();
 
     return $this->numFonts;


### PR DESCRIPTION
This also modifies the return of the `next` method to be null as defined by the interface.